### PR TITLE
Fix missing assignment

### DIFF
--- a/MYSSharedSettings/MYSSharedSettings.m
+++ b/MYSSharedSettings/MYSSharedSettings.m
@@ -319,7 +319,7 @@
         id object = nil;
 
         if (self.syncSettingsWithiCloud) {
-            [[NSUbiquitousKeyValueStore defaultStore] objectForKey:key];
+            object = [[NSUbiquitousKeyValueStore defaultStore] objectForKey:key];
         }
 
         if (!object) {


### PR DESCRIPTION
Great stuff, thanks! I'll get to replace a lot of boilerplate `NSUbiquitousKeyValueStore` stuff.

Fixed a missing assignment.
